### PR TITLE
Expose remaining fields in Dependency

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -46,9 +46,12 @@ pub struct Dependency {
     pub kind: DependencyKind,
     /// Whether this dependency is required or optional
     pub optional: bool,
-    uses_default_features: bool,
-    features: Vec<String>,
-    target: Option<String>,
+    /// Whether the default features in this dependency are used.
+    pub uses_default_features: bool,
+    /// The list of features enabled for this dependency.
+    pub features: Vec<String>,
+    /// The target this dependency is specific to.
+    pub target: Option<String>,
     #[doc(hidden)]
     #[serde(skip)]
     __do_not_match_exhaustively: (),


### PR DESCRIPTION
The private fields in Dependency are required to perform precise dependency resolution and there is no need to keep this fields private. This change makes all the fields public and gives them a short doc, except of course __do_not_match_exhaustively.